### PR TITLE
Fix Rd figure attributes to use CSS style for width

### DIFF
--- a/man/tradeOffTable.Rd
+++ b/man/tradeOffTable.Rd
@@ -25,7 +25,7 @@
 % A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
 \details{Displays the following trade-off table:
 
-	\if{html}{\figure{trade-off-table.png}{options: width="100\%" alt="Figure: DOE-trade-off-table.png"}}
+	\if{html}{\figure{trade-off-table.png}{options: style="width: 100%;" alt="Figure: DOE-trade-off-table.png"}}
     \if{latex}{\figure{trade-off-table.pdf}{options: width=7cm}}
 
 	The rows in the table are the number of experiments done in the fractional factorial (\eqn{n}).\cr


### PR DESCRIPTION
- Changed width='100%' to style='width: 100%;' in tradeOffTable.Rd
- Addresses R maintainers' NOTE about height/width attributes requiring pixels
- Uses CSS style attributes for percentage widths per HTML5 standard